### PR TITLE
More detailed test of scipy.linalg

### DIFF
--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -6,88 +6,43 @@ import asyncio
 
 
 # This is the output of the command run from the scipy root folder:
-# find scipy -name tests | sort | perl -pe 's@/@.@g'
+# find scipy/linalg -name 'test_*' | sort | perl -pe 's@/@.@g' | perl -pe 's@\.py$@@g'
 test_submodules_str = """
-scipy._build_utils.tests
-scipy.cluster.tests
-scipy.constants.tests
-scipy.fftpack.tests
-scipy.fft._pocketfft.tests
-scipy.fft.tests
-scipy.integrate._ivp.tests
-scipy.integrate.tests
-scipy.interpolate.tests
-scipy.io.arff.tests
-scipy.io._harwell_boeing.tests
-scipy.io.matlab.tests
-scipy.io.tests
-scipy._lib.tests
-scipy.linalg.tests
-scipy.misc.tests
-scipy.ndimage.tests
-scipy.odr.tests
-scipy.optimize.tests
-scipy.optimize._trustregion_constr.tests
-scipy.signal.tests
-scipy.sparse.csgraph.tests
-scipy.sparse.linalg._dsolve.tests
-scipy.sparse.linalg._eigen.arpack.tests
-scipy.sparse.linalg._eigen.lobpcg.tests
-scipy.sparse.linalg._eigen.tests
-scipy.sparse.linalg._isolve.tests
-scipy.sparse.linalg.tests
-scipy.sparse.tests
-scipy.spatial.tests
-scipy.spatial.transform.tests
-scipy.special.tests
-scipy.stats.tests
+scipy.linalg.tests.test_basic
+scipy.linalg.tests.test_blas
+scipy.linalg.tests.test_cython_blas
+scipy.linalg.tests.test_cythonized_array_utils
+scipy.linalg.tests.test_cython_lapack
+scipy.linalg.tests.test_decomp_cholesky
+scipy.linalg.tests.test_decomp_cossin
+scipy.linalg.tests.test_decomp_ldl
+scipy.linalg.tests.test_decomp_polar
+scipy.linalg.tests.test_decomp
+scipy.linalg.tests.test_decomp_update
+scipy.linalg.tests.test_fblas
+scipy.linalg.tests.test_interpolative
+scipy.linalg.tests.test_lapack
+scipy.linalg.tests.test_matfuncs
+scipy.linalg.tests.test_matmul_toeplitz
+scipy.linalg.tests.test_misc
+scipy.linalg.tests.test_procrustes
+scipy.linalg.tests.test_sketches
+scipy.linalg.tests.test_solvers
+scipy.linalg.tests.test_solve_toeplitz
+scipy.linalg.tests.test_special_matrices
 """
 
 test_submodules = test_submodules_str.split()
 
 expected_test_results_by_category = {
     "failed": [
-        "scipy.interpolate.tests",
-        "scipy.ndimage.tests",
-        "scipy.sparse.linalg._dsolve.tests",
-        "scipy.sparse.linalg._eigen.arpack.tests",
-        "scipy.special.tests",
     ],
     "fatal error or timeout": [
-        "scipy.fft.tests",
-        "scipy.linalg.tests",
-        "scipy.signal.tests",
-        "scipy.sparse.linalg._isolve.tests",
-        "scipy.sparse.linalg.tests",
-        "scipy.sparse.tests",
-        "scipy.spatial.tests",
-        "scipy.stats.tests",
     ],
-    "passed": [
-        "scipy._build_utils.tests",
-        "scipy.cluster.tests",
-        "scipy.constants.tests",
-        "scipy.fftpack.tests",
-        "scipy.fft._pocketfft.tests",
-        "scipy.io.arff.tests",
-        "scipy.io._harwell_boeing.tests",
-        "scipy.io.matlab.tests",
-        "scipy.misc.tests",
-        "scipy.odr.tests",
-        "scipy.optimize._trustregion_constr.tests",
-        "scipy.sparse.csgraph.tests",
-        "scipy.sparse.linalg._eigen.lobpcg.tests",
-        "scipy.sparse.linalg._eigen.tests",
-        "scipy.spatial.transform.tests",
-    ],
+    "passed": test_submodules,
     "pytest usage error": [
-        "scipy.integrate._ivp.tests",
     ],
     "tests collection error": [
-        "scipy.integrate.tests",
-        "scipy.io.tests",
-        "scipy._lib.tests",
-        "scipy.optimize.tests",
     ],
 }
 


### PR DESCRIPTION
From https://github.com/lesteve/scipy-tests-pyodide/actions/runs/3829976114/jobs/6517263661
```
category fatal error or timeout (5 modules)
    scipy.linalg.tests.test_basic
    scipy.linalg.tests.test_blas
    scipy.linalg.tests.test_cython_blas
    scipy.linalg.tests.test_decomp_cossin
    scipy.linalg.tests.test_lapack
category passed (17 modules)
    scipy.linalg.tests.test_cythonized_array_utils
    scipy.linalg.tests.test_cython_lapack
    scipy.linalg.tests.test_decomp_cholesky
    scipy.linalg.tests.test_decomp_ldl
    scipy.linalg.tests.test_decomp_polar
    scipy.linalg.tests.test_decomp
    scipy.linalg.tests.test_decomp_update
    scipy.linalg.tests.test_fblas
    scipy.linalg.tests.test_interpolative
    scipy.linalg.tests.test_matfuncs
    scipy.linalg.tests.test_matmul_toeplitz
    scipy.linalg.tests.test_misc
    scipy.linalg.tests.test_procrustes
    scipy.linalg.tests.test_sketches
    scipy.linalg.tests.test_solvers
    scipy.linalg.tests.test_solve_toeplitz
    scipy.linalg.tests.test_special_matrices
```

## `scipy.linalg.tests.test_basic`

This passes:
```
node --experimental-fetch scipy-pytest.js --pyargs scipy.linalg.tests.test_basic -v -k 'not test_hermitian and not (TestLstsq and random_exact)'
```

memory corruption for `test_hermitian`

memory corruption for 'TestLstsq and random_exact'

## `scipy.linalg.tests.test_blas`

This passes:
```
node --experimental-fetch scipy-pytest.js scipy.linalg.tests.test_blas -v -k 'not test_complex_dotu'
```

my feeling is that complex does not work very well right now (22 December 2022) with Pyodide
`test_complex_dotu` seems like a genuine signature mismatch

```py
from scipy.linalg import _fblas

_fblas.cdotu([3j, -4, 3-4j], [2, 3, 1])
```

stack-trace with debug symbols:
```
RuntimeError: null function or function signature mismatch
    at f2py_rout__fblas_cdotu (001e2656:0x13468)
    at fortran_call (0003e3ba:0x6642)
    at method_call_trampoline (pyodide.asm.js:9750:33)
    at _PyObject_MakeTpCall (pyodide.asm.wasm:0x1309ec)
    at call_function (pyodide.asm.wasm:0x1ecb7f)
    at _PyEval_EvalFrameDefault (pyodide.asm.wasm:0x1ea7d6)
    at _PyEval_Vector (pyodide.asm.wasm:0x1e4de9)
    at PyEval_EvalCode (pyodide.asm.wasm:0x1e41b5)
    at builtin_eval (pyodide.asm.wasm:0x1e1558)
    at cfunction_vectorcall_FASTCALL (pyodide.asm.wasm:0x16c465)
```

called with 6 arguments:
```
call_indirect (param i32 i32 i32 i32 i32 i32) (result i32)
```
But function has 8 arguments:
```
(func $f2pywrapcdotu_ (;227;) (export "f2pywrapcdotu_") (param $var0 i32) (param $var1 i32) (param $var2 i32) (param $var3 i32) (param $var4 i32) (param $var5 i32) (param $var6 i32) (param $var7 i32) (result i32)
```

## `scipy.linalg.tests.test_cython_blas`

This passes:
```
node --experimental-fetch scipy-pytest.js scipy.linalg.tests.test_cython_blas -v -k 'not complex'
```

fatal error for `complex` (2 tests: `::TestWfuncPointers::test_complex_args` and `::TestWfuncPointers::test_double_complex_args`). This is probably related to `cdotu` above?

``` 
TypeError: Cannot read properties of undefined (reading 'apply')
    at stubs.<computed> (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:16567:33)
    at cdotuwrp_ (wasm://wasm/000a165a:wasm-function[552]:0x1beeb)
    at __pyx_pw_5scipy_6linalg_11cython_blas_3_test_cdotu (wasm://wasm/000a165a:wasm-function[280]:0x4a03)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33)
    at cfunction_call (wasm://wasm/02005366:wasm-function[1921]:0x16c819)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33)
    at _PyObject_MakeTpCall (wasm://wasm/02005366:wasm-function[997]:0x1309ec)
    at call_function (wasm://wasm/02005366:wasm-function[3082]:0x1ecb7f)
    at _PyEval_EvalFrameDefault (wasm://wasm/02005366:wasm-function[3073]:0x1ea7d6)
    at _PyEval_Vector (wasm://wasm/02005366:wasm-function[3070]:0x1e4de9) {
  pyodide_fatal_error: true
}
```

Debugging a little bit it seems like it can not correctly resolve the symbol `wcdotu_` for some reason:
```
prop="wcdotu_"
resolved=undefined
```

And it ends up calling `.apply` on undefined indeed:
```js
if (!resolved) resolved = resolveSymbol(prop);
return resolved.apply(null, arguments);
```


## `scipy.linalg.tests.test_decomp_cossin`

All tests in `scipy.linalg.tests.test_decomp_cossin` seems to raise Pyodide fatal errors (or at least I could not find any that did not in a reasonable amount of time)

Same type of error as previous section:
```
TypeError: Cannot read properties of undefined (reading 'apply')
```

## `scipy.linalg.tests.test_lapack`

This runs with one failure (but no Pyodide fatal errors):
```
node --experimental-fetch scipy-pytest.js scipy.linalg.tests.test_lapack -v -k 'not larfg_larf and not geqrt_gemqrt and not tpqrt_tpmqrt and not test_geqrfp and not orcsd_uncsd and not test_gtsvx_error_singular'
```

- `larfg_larf`: opened https://github.com/pyodide/pyodide/issues/3379 about larfg signature mismatch.
- `geqrt_gemqrt`: apply called on undefined
```
TypeError: Cannot read properties of undefined (reading 'apply')
    at stubs.<computed> (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:16567:33)
    at sgeqrt_ (wasm://wasm/00677c62:wasm-function[771]:0xd9bcd)
    at f2py_rout__flapack_sgeqrt (wasm://wasm/00677c62:wasm-function[574]:0x9d45e)
    at fortran_call (wasm://wasm/0003e3ba:wasm-function[103]:0x6642)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33)
    at _PyObject_MakeTpCall (wasm://wasm/02005366:wasm-function[997]:0x1309ec)
    at call_function (wasm://wasm/02005366:wasm-function[3082]:0x1ecb7f)
    at _PyEval_EvalFrameDefault (wasm://wasm/02005366:wasm-function[3073]:0x1e9dad)
    at _PyEval_Vector (wasm://wasm/02005366:wasm-function[3070]:0x1e4de9)
    at _PyFunction_Vectorcall (wasm://wasm/02005366:wasm-function[1005]:0x1310e0) {
  pyodide_fatal_error: true
}
```

- `tpqrt_tpmqrt` apply called on undefined
```
TypeError: Cannot read properties of undefined (reading 'apply')
    at stubs.<computed> (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:16567:33)
    at stpqrt_ (wasm://wasm/00677c62:wasm-function[774]:0xdb2dc)
    at f2py_rout__flapack_stpqrt (wasm://wasm/00677c62:wasm-function[582]:0x9feb3)
    at fortran_call (wasm://wasm/0003e3ba:wasm-function[103]:0x6642)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33)
    at _PyObject_MakeTpCall (wasm://wasm/02005366:wasm-function[997]:0x1309ec)
    at call_function (wasm://wasm/02005366:wasm-function[3082]:0x1ecb7f)
    at _PyEval_EvalFrameDefault (wasm://wasm/02005366:wasm-function[3073]:0x1e9dad)
    at _PyEval_Vector (wasm://wasm/02005366:wasm-function[3070]:0x1e4de9)
    at _PyFunction_Vectorcall (wasm://wasm/02005366:wasm-function[1005]:0x1310e0) {
  pyodide_fatal_error: true
}
```
- `test_geqrfp` apply called on undefined
```
TypeError: Cannot read properties of undefined (reading 'apply')
    at stubs.<computed> (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:16567:33)
    at sgeqrfp_ (wasm://wasm/00677c62:wasm-function[770]:0xd99f7)
    at f2py_rout__flapack_sgeqrfp (wasm://wasm/00677c62:wasm-function[267]:0x350f2)
    at fortran_call (wasm://wasm/0003e3ba:wasm-function[103]:0x6642)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33)
    at _PyObject_MakeTpCall (wasm://wasm/02005366:wasm-function[997]:0x1309ec)
    at call_function (wasm://wasm/02005366:wasm-function[3082]:0x1ecb7f)
    at _PyEval_EvalFrameDefault (wasm://wasm/02005366:wasm-function[3073]:0x1e9dad)
    at _PyEval_Vector (wasm://wasm/02005366:wasm-function[3070]:0x1e4de9)
    at _PyFunction_Vectorcall (wasm://wasm/02005366:wasm-function[1005]:0x1310e0) {
  pyodide_fatal_error: true
}
```

- `orcsd_uncsd` apply called on undefined
```
TypeError: Cannot read properties of undefined (reading 'apply')
    at stubs.<computed> (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:16567:33)
    at sorcsd_ (wasm://wasm/00677c62:wasm-function[775]:0xdb95f)
    at sorcsd_ (wasm://wasm/00677c62:wasm-function[775]:0xdb74d)
    at f2py_rout__flapack_sorcsd_lwork (wasm://wasm/00677c62:wasm-function[552]:0x9689c)
    at fortran_call (wasm://wasm/0003e3ba:wasm-function[103]:0x6642)
    at _PyObject_Call (wasm://wasm/02005366:wasm-function[1003]:0x131064)
    at PyObject_Call (wasm://wasm/02005366:wasm-function[1004]:0x13109d)
    at _PyEval_EvalFrameDefault (wasm://wasm/02005366:wasm-function[3073]:0x1eadba)
    at _PyEval_Vector (wasm://wasm/02005366:wasm-function[3070]:0x1e4de9)
    at _PyFunction_Vectorcall (wasm://wasm/02005366:wasm-function[1005]:0x1310e0) {
  pyodide_fatal_error: true
```
- `test_gtsvx_error_singular` seems only a problem with complex
```
RuntimeError: Aborted(). Build with -sASSERTIONS for more info.
    at abort (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:6887:15)
    at _abort (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:19989:7)
    at sig_die (wasm://wasm/00e478ee:wasm-function[1710]:0x375e9d)
    at c_div (wasm://wasm/00e478ee:wasm-function[1722]:0x376480)
    at cgtts2_ (wasm://wasm/00e478ee:wasm-function[901]:0x1dee7d)
    at cgttrs_ (wasm://wasm/00e478ee:wasm-function[900]:0x1dec6d)
    at cgtsvx_ (wasm://wasm/00e478ee:wasm-function[898]:0x1de3f3)
    at f2py_rout__flapack_cgtsvx (wasm://wasm/00677c62:wasm-function[342]:0x54dad)
    at fortran_call (wasm://wasm/0003e3ba:wasm-function[103]:0x6642)
    at method_call_trampoline (/home/lesteve/dev/scipy-tests-pyodide/node_modules/pyodide/pyodide.asm.js:9750:33) {
  pyodide_fatal_error: true
}
```
