### PR TITLE
More detailed test of scipy.signal.tests

### DIFF
--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -6,41 +6,26 @@ import asyncio
 
 
 # This is the output of the command run from the scipy root folder:
-# find scipy -name tests | sort | perl -pe 's@/@.@g'
+# find scipy/signal/tests -name 'test_*' | sort | perl -pe 's@/@.@g' | perl -pe 's@\.py$@@g'
 test_submodules_str = """
-scipy._build_utils.tests
-scipy.cluster.tests
-scipy.constants.tests
-scipy.fftpack.tests
-scipy.fft._pocketfft.tests
-scipy.fft.tests
-scipy.integrate._ivp.tests
-scipy.integrate.tests
-scipy.interpolate.tests
-scipy.io.arff.tests
-scipy.io._harwell_boeing.tests
-scipy.io.matlab.tests
-scipy.io.tests
-scipy._lib.tests
-scipy.linalg.tests
-scipy.misc.tests
-scipy.ndimage.tests
-scipy.odr.tests
-scipy.optimize.tests
-scipy.optimize._trustregion_constr.tests
-scipy.signal.tests
-scipy.sparse.csgraph.tests
-scipy.sparse.linalg._dsolve.tests
-scipy.sparse.linalg._eigen.arpack.tests
-scipy.sparse.linalg._eigen.lobpcg.tests
-scipy.sparse.linalg._eigen.tests
-scipy.sparse.linalg._isolve.tests
-scipy.sparse.linalg.tests
-scipy.sparse.tests
-scipy.spatial.tests
-scipy.spatial.transform.tests
-scipy.special.tests
-scipy.stats.tests
+scipy.signal.tests.test_array_tools
+scipy.signal.tests.test_bsplines
+scipy.signal.tests.test_cont2discrete
+scipy.signal.tests.test_czt
+scipy.signal.tests.test_dltisys
+scipy.signal.tests.test_filter_design
+scipy.signal.tests.test_fir_filter_design
+scipy.signal.tests.test_ltisys
+scipy.signal.tests.test_max_len_seq
+scipy.signal.tests.test_peak_finding
+scipy.signal.tests.test_result_type
+scipy.signal.tests.test_savitzky_golay
+scipy.signal.tests.test_signaltools
+scipy.signal.tests.test_spectral
+scipy.signal.tests.test_upfirdn
+scipy.signal.tests.test_waveforms
+scipy.signal.tests.test_wavelets
+scipy.signal.tests.test_windows
 """
 
 test_submodules = test_submodules_str.split()


### PR DESCRIPTION
From https://github.com/lesteve/scipy-tests-pyodide/actions/runs/3829972683/jobs/6517255299:
```
category failed (2 modules)
    scipy.signal.tests.test_max_len_seq
    scipy.signal.tests.test_signaltools
category passed (16 modules)
    scipy.signal.tests.test_array_tools
    scipy.signal.tests.test_bsplines
    scipy.signal.tests.test_cont2discrete
    scipy.signal.tests.test_czt
    scipy.signal.tests.test_dltisys
    scipy.signal.tests.test_filter_design
    scipy.signal.tests.test_fir_filter_design
    scipy.signal.tests.test_ltisys
    scipy.signal.tests.test_peak_finding
    scipy.signal.tests.test_result_type
    scipy.signal.tests.test_savitzky_golay
    scipy.signal.tests.test_spectral
    scipy.signal.tests.test_upfirdn
    scipy.signal.tests.test_waveforms
    scipy.signal.tests.test_wavelets
    scipy.signal.tests.test_windows
```

There are some errors in `scipy.signal.tests.test_max_len_seq` due to some issues with pythranized function.
```
TypeError: Invalid call to pythranized function `_max_len_seq_inner(intc[:], int8[:], int, int, int8[:])'
Candidates are:

    - _max_len_seq_inner(int[:], int8[:], int, int, int8[:])
    - _max_len_seq_inner(int64[:], int8[:], int, int, int8[:])
```

`scipy.signal.tests.test_signaltools` failures are because they use threads.

Previous fatal errors in `scipy.signal.tests.test_spectral` were due to  CppException https://github.com/pyodide/pyodide/issues/3382