### PR TITLE
More detailed test of scipy.spatial.tests

### DIFF
--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -6,41 +6,16 @@ import asyncio
 
 
 # This is the output of the command run from the scipy root folder:
-# find scipy -name tests | sort | perl -pe 's@/@.@g'
+# find scipy/spatial/tests -name 'test_*' | sort | perl -pe 's@/@.@g' | perl -pe 's@\.py$@@g'
 test_submodules_str = """
-scipy._build_utils.tests
-scipy.cluster.tests
-scipy.constants.tests
-scipy.fftpack.tests
-scipy.fft._pocketfft.tests
-scipy.fft.tests
-scipy.integrate._ivp.tests
-scipy.integrate.tests
-scipy.interpolate.tests
-scipy.io.arff.tests
-scipy.io._harwell_boeing.tests
-scipy.io.matlab.tests
-scipy.io.tests
-scipy._lib.tests
-scipy.linalg.tests
-scipy.misc.tests
-scipy.ndimage.tests
-scipy.odr.tests
-scipy.optimize.tests
-scipy.optimize._trustregion_constr.tests
-scipy.signal.tests
-scipy.sparse.csgraph.tests
-scipy.sparse.linalg._dsolve.tests
-scipy.sparse.linalg._eigen.arpack.tests
-scipy.sparse.linalg._eigen.lobpcg.tests
-scipy.sparse.linalg._eigen.tests
-scipy.sparse.linalg._isolve.tests
-scipy.sparse.linalg.tests
-scipy.sparse.tests
-scipy.spatial.tests
-scipy.spatial.transform.tests
-scipy.special.tests
-scipy.stats.tests
+scipy.spatial.tests.test_distance
+scipy.spatial.tests.test_hausdorff
+scipy.spatial.tests.test_kdtree
+scipy.spatial.tests.test__plotutils
+scipy.spatial.tests.test__procrustes
+scipy.spatial.tests.test_qhull
+scipy.spatial.tests.test_slerp
+scipy.spatial.tests.test_spherical_voronoi
 """
 
 test_submodules = test_submodules_str.split()


### PR DESCRIPTION
From https://github.com/lesteve/scipy-tests-pyodide/actions/runs/3829971508/jobs/6517252664
```
category failed (1 modules)
    scipy.spatial.tests.test_kdtree
category passed (7 modules)
    scipy.spatial.tests.test_distance
    scipy.spatial.tests.test_hausdorff
    scipy.spatial.tests.test__plotutils
    scipy.spatial.tests.test__procrustes
    scipy.spatial.tests.test_qhull
    scipy.spatial.tests.test_slerp
    scipy.spatial.tests.test_spherical_voronoi
```

`scipy.spatial.tests.test_kdtree` failures because tests create threads (4 test failures)

This passes:
```
node --experimental-fetch scipy-pytest.js scipy.spatial.tests -k 'not multithreading and not parallel'
```


```
798 passed, 5 skipped, 4 deselected in 145.79s (0:02:25)
```

Previous fatal errors in `scipy.spatial.tests.test_distance` were fixed by https://github.com/pyodide/pyodide/issues/3382 (`CppException` issues)