### PR TITLE
Do not unvendor scipy tests in Pyodide build

### DIFF
--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -8,6 +8,9 @@ name: build-pyodide-debug
 on:
   push:
     branches: [main]
+  pull_requests:
+    branches: [main]
+
   # daily scheduled build at 1am
   schedule:
     - cron: "0 1 * * *"
@@ -59,6 +62,8 @@ jobs:
           cd pyodide
           git show --stat
           pip install -r requirements.txt
+          # Do not unvendor scipy tests since some have compiled extensions
+          perl -pi -e 's@build:@build:\n  - unvendor-tests: false@' packages/scipy/meta.yaml
 
       - name: Build emsdk
         shell: bash -l {0}

--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -8,9 +8,6 @@ name: build-pyodide-debug
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
   # daily scheduled build at 1am
   schedule:
     - cron: "0 1 * * *"

--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -8,7 +8,7 @@ name: build-pyodide-debug
 on:
   push:
     branches: [main]
-  pull_requests:
+  pull_request:
     branches: [main]
 
   # daily scheduled build at 1am

--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -63,7 +63,7 @@ jobs:
           git show --stat
           pip install -r requirements.txt
           # Do not unvendor scipy tests since some have compiled extensions
-          perl -pi -e 's@build:@build:\n  - unvendor-tests: false@' packages/scipy/meta.yaml
+          perl -pi -e 's@build:@build:\n  unvendor-tests: false@' packages/scipy/meta.yaml
 
       - name: Build emsdk
         shell: bash -l {0}


### PR DESCRIPTION
Some of the tests have built extensions which cause pytest collection errors.