### PR TITLE
Remove unnecessary steps in scipy tests build

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,6 @@ jobs:
       PYODIDE_JS_VERSION: '0.22.0'
       PYTHON_VERSION: '3.10.7'
       NODE_VERSION: 18
-      EMSCRIPTEN_VERSION: 3.1.29
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -68,11 +67,6 @@ jobs:
           ls -ltrh pyodide/dist
           # Put back lost permission in artifact
           chmod u+x pyodide/dist/python
-
-      - uses: mymindstorm/setup-emsdk@v11
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
-          actions-cache-folder: emsdk-cache
 
       - name: set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,20 +25,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: set up python
-        id: setup-python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: clone pyodide repo
-        shell: bash -l {0}
-        run: |
-          git clone https://github.com/pyodide/pyodide --depth 1
-          cd pyodide
-          git log -1
-          pip install -e ./pyodide-build
-
       - name: Download latest Pyodide debug build
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,6 @@ jobs:
   build-wasm-emscripten:
     runs-on: ubuntu-latest
     env:
-      PYODIDE_VERSION: '0.22.0'
-      PYODIDE_JS_VERSION: '0.22.0'
       PYTHON_VERSION: '3.10.7'
       NODE_VERSION: 18
     steps:
@@ -61,7 +59,7 @@ jobs:
 
       - name: install Pyodide
         run: |
-          npm install "pyodide@$PYODIDE_JS_VERSION"
+          npm install "pyodide"
 
       - name: install debug build
         run: |


### PR DESCRIPTION
There are no need for emscripten, python or clone pyodide repo, since we only fetch artifact from Pyodide build and use node to run tests.