### PR TITLE
Update conftest.py after OpenBLAS switch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,8 @@ jobs:
             artifacts = artifacts_response.data.artifacts;
 
             const most_recent_artifact = artifacts[0];
-            console.log('artifact used', most_recent_artifact);
+            console.log('artifact:', most_recent_artifact);
+            console.log(`action url: https://github.com/lesteve/scipy-tests-pyodide/actions/runs/${most_recent_artifact.workflow_run.id}`);
 
             const response = await github.rest.actions.downloadArtifact({
                 owner: owner, repo: repo, artifact_id: most_recent_artifact.id, archive_format: "zip"});

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,8 @@ jobs:
             artifacts = artifacts_response.data.artifacts;
 
             const most_recent_artifact = artifacts[0];
-            
+            console.log('artifact used', most_recent_artifact);
+
             const response = await github.rest.actions.downloadArtifact({
                 owner: owner, repo: repo, artifact_id: most_recent_artifact.id, archive_format: "zip"});
             console.log(`Downloaded ${response.data.byteLength / 1000000} MB`);

--- a/conftest.py
+++ b/conftest.py
@@ -27,17 +27,9 @@ tests_to_mark = [
     ("test_numpy.py::TestFFTThreadSafe", xfail, "no threading support"),
     ("test_numpy.py::test_multiprocess", xfail, "no process support"),
     # scipy/linalg tests
-    ("test_basic.py.+test_hermitian", skip, "memory corruption"),
-    ("test_basic.py.+TestLstsq.+random_exact", skip, "memory corruption"),
     ("test_blas.+test_complex_dotu", skip, "signature mismatch"),
     ("test_cython_blas.+complex", skip, "signature mismatch"),
-    ("test_decomp_cossin", skip, "missing symbol"),
-    ("test_lapack.py.+larfg_larf", skip, "missing symbol"),
-    ("test_lapack.py.+geqrt_gemqrt", skip, "missing symbol"),
-    ("test_lapack.py.+tpqrt_tpmqrt", skip, "missing symbol"),
-    ("test_lapack.py.+test_geqrfp", skip, "missing symbol"),
-    ("test_lapack.py.+orcsd_uncsd", skip, "missing symbol"),
-    ("test_lapack.py.+test_gtsvx_error_singular", skip, "missing symbol"),
+    ("test_lapack.py.+larfg_larf", skip, "signature mismatch"),
     # scipy/ndimage/tests
     ("test_filters.py::TestThreading", xfail, "no threading support"),
     # scipy/optimize/tests
@@ -65,12 +57,6 @@ tests_to_mark = [
     ),
     # scipy/sparse/tests
     ("test_arpack.py::test_parallel_threads", xfail, "no threading support"),
-    ("test_gcrotmk.+test_cornercase", skip, "memory corruption"),
-    ("test_iterative.+precond_dummy", skip, "memory corruption"),
-    ("test_iterative.+test_convergence", skip, "memory corruption"),
-    ("test_iterative.+gcrotmk", skip, "memory corruption"),
-    ("test_iterative.+lgmres", skip, "memory corruption"),
-    ("test_iterative.+test_maxiter$", skip, "memory corruption"),
     ("test_linsolve.py::TestSplu.test_threads_parallel", xfail, "no threading support"),
     ("test_propack", skip, "signature mismatch"),
     ("test_sparsetools.py::test_threads", xfail, "no threading support"),

--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -23,7 +23,7 @@ expected_test_results = {
     "scipy.io.matlab.tests": ["passed"],
     "scipy.io.tests": ["tests collection error"],
     "scipy._lib.tests": ["passed"],
-    "scipy.linalg.tests": ["failed"],
+    "scipy.linalg.tests": ["passed"],
     "scipy.misc.tests": ["passed"],
     "scipy.ndimage.tests": ["passed"],
     "scipy.odr.tests": ["passed"],


### PR DESCRIPTION
Some tests have been fixed by switching to OpenBLAS.

This will very likely need to be restarted once https://github.com/lesteve/scipy-tests-pyodide/actions/runs/4673779452 completes to use artifacts that use OpenBLAS.