### PR TITLE
Fix meson error when building numpy

### DIFF
--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          sudo apt install -y build-essential git
-          conda install -y nodejs ccache f2c pkg-config swig make patch pkg-config texinfo autoconf automake libtool
+          sudo apt install -y build-essential git pkg-config
+          conda install -y nodejs ccache f2c swig make patch pkg-config texinfo autoconf automake libtool
 
       - name: clone pyodide repo
         shell: bash -l {0}

--- a/.github/workflows/build-pyodide-debug.yml
+++ b/.github/workflows/build-pyodide-debug.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash -l {0}
         run: |
           sudo apt install -y build-essential git pkg-config
-          conda install -y nodejs ccache f2c swig make patch pkg-config texinfo autoconf automake libtool
+          conda install -y nodejs ccache f2c swig make patch texinfo autoconf automake libtool
 
       - name: clone pyodide repo
         shell: bash -l {0}


### PR DESCRIPTION
```
Has header "Python.h" with dependency python-3.11: NO                           
                                                                                
../../meson.build:44:2: ERROR: Problem encountered: Cannot compile `Python.h`.  
Perhaps you need to install python-dev|python-devel                             
                                                                                
A full log can be found at                                                      
/home/runner/work/scipy-tests-pyodide/scipy-tests-pyodide/pyodide/packages/numpy
/build/numpy-1.26.1/.mesonpy-z5u0zovu/build/meson-logs/meson-log.txt
```