### PR TITLE
Skip temporarily fatal error after switch to meson

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,9 @@ memory_corruption_msg = "memory corruption"
 temporary_jspi_msg = (
     "JSPI temporary skipping, see https://github.com/pyodide/pyodide/issues/4249"
 )
+temporary_meson_msg = (
+    "temporary skipping after switch to meson, see https://github.com/pyodide/pyodide/issues/4310"
+)
 
 tests_to_mark = [
     # scipy/_lib/tests
@@ -96,6 +99,7 @@ tests_to_mark = [
     ("test_propack", skip, signature_mismatch_msg),
     ("test_sparsetools.py::test_threads", xfail, thread_msg),
     ("test_array_api.py::test_sparse_dense_divide", xfail, fp_exception_msg),
+    ("test_matfuncs.py::TestExpM.test_logm_consistency", skip, temporary_meson_msg),
     # scipy/spatial/tests
     (
         "test_kdtree.py::test_query_ball_point_multithreading",
@@ -187,5 +191,5 @@ def pytest_collection_modifyitems(config, items):
         full_name = f"{path}::{name}"
         for pattern, mark, reason in tests_to_mark:
             if re.search(pattern, full_name):
-                print(full_name)
+                # print(full_name)
                 item.add_marker(mark(reason=reason))

--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -7,7 +7,6 @@ import asyncio
 # root folder:
 # find scipy -name tests | sort | perl -pe 's@/@.@g'
 expected_test_results = {
-    "scipy._build_utils.tests": ["passed"],
     "scipy.cluster.tests": ["passed"],
     "scipy.constants.tests": ["passed"],
     "scipy.fftpack.tests": ["passed"],


### PR DESCRIPTION
Pyodide issue tracked in https://github.com/pyodide/pyodide/issues/4310.

Also `_built_utils` is not in the built wheels any more when using meson apparently. This is not crucial to test this.