### PR TITLE
Add datasets module and xfail most tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,8 @@ tests_to_mark = [
     ("test_ccallback.py::test_threadsafety", xfail, thread_msg),
     ("test_import_cycles.py::test_modules_importable", xfail, process_msg),
     ("test_import_cycles.py::test_public_modules_importable", xfail, process_msg),
+    # scipy/datasets/tests
+    ("test_data.py::TestDatasets", xfail, "TODO datasets not working right now"),
     # scipy/fft/tests
     (
         r"test_basic.py::TestFFT1D.test_dtypes\[float32-numpy\]",

--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -9,6 +9,7 @@ import asyncio
 expected_test_results = {
     "scipy.cluster.tests": ["passed"],
     "scipy.constants.tests": ["passed"],
+    "scipy.datasets.tests": ["passed"],
     "scipy.fftpack.tests": ["passed"],
     "scipy.fft._pocketfft.tests": ["passed"],
     "scipy.fft.tests": ["passed"],

--- a/scipy-pytest.js
+++ b/scipy-pytest.js
@@ -63,7 +63,7 @@ async function main() {
     `);
 
     await pyodide.runPythonAsync(
-        "import micropip; micropip.install(['pytest', 'hypothesis'])");
+        "import micropip; micropip.install(['pytest', 'hypothesis', 'pooch', 'lzma'])");
     let pytest = pyodide.pyimport("pytest");
     let args = process.argv.slice(2);
     console.log('pytest args:', args);


### PR DESCRIPTION
I guess this was added after I created the list of scipy tests modules ...

The kind of errors I get, maybe this is just a matter of doing `pyodide_http.patch_all()`?

```
_____________________ TestDatasets.test_electrocardiogram ______________________

self = <scipy.datasets.tests.test_data.TestDatasets object at 0x4c03ac0>

    @pytest.fixture(scope='module', autouse=True)
    def test_download_all(self):
        # This fixture requires INTERNET CONNECTION
    
        # test_setup phase
>       download_all()

/lib/python3.12/site-packages/scipy/datasets/tests/test_data.py:34: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/lib/python3.12/site-packages/scipy/datasets/_download_all.py:42: in download_all
    pooch.retrieve(url=_registry.registry_urls[dataset_name],
/lib/python3.12/site-packages/pooch/core.py:239: in retrieve
    stream_download(url, full_path, known_hash, downloader, pooch=None)
/lib/python3.12/site-packages/pooch/core.py:807: in stream_download
    downloader(url, tmp, pooch)
/lib/python3.12/site-packages/pooch/downloaders.py:220: in __call__
    response = requests.get(url, timeout=timeout, **kwargs)
/lib/python3.12/site-packages/requests/api.py:73: in get
    return request("get", url, params=params, **kwargs)
/lib/python3.12/site-packages/requests/api.py:59: in request
    return session.request(method=method, url=url, **kwargs)
/lib/python3.12/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
/lib/python3.12/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
/lib/python3.12/site-packages/requests/adapters.py:667: in send
    resp = conn.urlopen(
/lib/python3.12/site-packages/urllib3/connectionpool.py:789: in urlopen
    response = self._make_request(
/lib/python3.12/site-packages/urllib3/connectionpool.py:495: in _make_request
    conn.request(
/lib/python3.12/site-packages/urllib3/contrib/emscripten/connection.py:118: in request
    self._response = send_request(request)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

request = EmscriptenRequest(method='GET', url='https://raw.githubusercontent.com:443/scipy/dataset-ascent/main/ascent.dat', para...3', 'Accept-encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'}, timeout=30, decode_content=False)

    def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
        try:
>           js_xhr = js.XMLHttpRequest.new()
E           AttributeError: XMLHttpRequest

/lib/python3.12/site-packages/urllib3/contrib/emscripten/fetch.py:367: AttributeError
```