### PR TITLE
Run scipy tests with -m 'not slow'

### DIFF
--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -129,7 +129,7 @@ def run_tests_for_module(module_str):
     # take more than 60s to run
     use_longer_timeout = "interpolate" in module_str or "stats" in module_str
     timeout_without_output = 120 if use_longer_timeout else 60
-    command_str = f"node --experimental-fetch scipy-pytest.js --pyargs {module_str} -v --durations 20 -ra"
+    command_str = f"node --experimental-fetch scipy-pytest.js --pyargs {module_str} -v --durations 20 -ra -m 'not slow'"
     command_list = shlex.split(command_str)
     command_result = execute_command_with_timeout(
         command_list=command_list, timeout_without_output=timeout_without_output


### PR DESCRIPTION
To get an idea whether this is faster or not and by how much.

According to https://github.com/lesteve/scipy-tests-pyodide/actions/workflows/run-tests.yml it shaves 15 minutes i.e. ~25 minutes instead of ~40 minutes.